### PR TITLE
Fix const strings declared as char*

### DIFF
--- a/include/mfmidi.h
+++ b/include/mfmidi.h
@@ -46,7 +46,7 @@ protected:
     virtual void Mf_chanprefix(int) = 0;
     virtual void Mf_portprefix(int) = 0;
     virtual void Mf_eot() = 0;
-    virtual void Mf_error(char *) = 0;
+    virtual void Mf_error(const char *) = 0;
     virtual void Mf_header(int,int,int) = 0;
     virtual void Mf_on(int,int,int) = 0;
     virtual void Mf_off(int,int,int) = 0;
@@ -81,10 +81,10 @@ private:
     int egetc();
     int msgleng();
 
-    int readmt(char*,int);
+    int readmt(const char*,int);
     long to32bit(int,int,int,int);
     int to16bit(int,int);
-    void mferror(char *);
+    void mferror(const char *);
     void badbyte(int);
     void metaevent(int);
     void msgadd(int);

--- a/src/allegrord.cpp
+++ b/src/allegrord.cpp
@@ -39,7 +39,7 @@ public:
     long parse_int(string &field);
     int find_real_in(string &field, int n);
     double parse_real(string &field);
-    void parse_error(string &field, long offset, char *message);
+    void parse_error(string &field, long offset, const char *message);
     double parse_dur(string &field, double base);
     double parse_after_dur(double dur, string &field, int n, double base);
     double parse_loud(string &field);
@@ -422,7 +422,7 @@ bool Alg_reader::parse()
 long Alg_reader::parse_chan(string &field)
 {
     const char *int_string = field.c_str() + 1;
-    char *msg = "Integer or - expected";
+    const char *msg = "Integer or - expected";
     const char *p = int_string;
     char c;
     // check that all chars in int_string are digits or '-':
@@ -449,7 +449,7 @@ long Alg_reader::parse_chan(string &field)
 long Alg_reader::parse_int(string &field)
 {
     const char *int_string = field.c_str() + 1;
-    char *msg = "Integer expected";
+    const char *msg = "Integer expected";
     const char *p = int_string;
     char c;
     // check that all chars in int_string are digits:
@@ -491,7 +491,7 @@ int Alg_reader::find_real_in(string &field, int n)
 
 double Alg_reader::parse_real(string &field)
 {
-    char *msg = "Real expected";
+    const char *msg = "Real expected";
     int last = find_real_in(field, 1);
     string real_string = field.substr(1, last - 1);
     if (last <= 1 || last < (int) field.length()) {
@@ -502,7 +502,7 @@ double Alg_reader::parse_real(string &field)
 }
 
 
-void Alg_reader::parse_error(string &field, long offset, char *message)
+void Alg_reader::parse_error(string &field, long offset, const char *message)
 {
     int position = line_parser.pos - field.length() + offset;
     error_flag = true;
@@ -520,9 +520,9 @@ double duration_lookup[] = { 0.25, 0.5, 1.0, 2.0, 4.0 };
 
 double Alg_reader::parse_dur(string &field, double base)
 {
-    char *msg = "Duration expected";
-    char *durs = "SIQHW";
-    char *p;
+    const char *msg = "Duration expected";
+    const char *durs = "SIQHW";
+    const char *p;
     int last;
     double dur;
     if (field.length() < 2) {
@@ -578,7 +578,7 @@ double Alg_reader::parse_after_dur(double dur, string &field,
 }
 
 struct loud_lookup_struct {
-    char *str;
+    const char *str;
     int val;
 } loud_lookup[] = { {"FFF", 127}, {"FF", 120}, {"F", 110}, {"MF", 100}, 
                     {"MP", 90}, {"P", 80}, {"PP", 70}, {"PPP", 60}, 
@@ -587,7 +587,7 @@ struct loud_lookup_struct {
 
 double Alg_reader::parse_loud(string &field)
 {
-    char *msg = "Loudness expected";
+    const char *msg = "Loudness expected";
     if (isdigit(field[1])) {
         return parse_int(field);
     } else {
@@ -613,9 +613,9 @@ int key_lookup[] = {21, 23, 12, 14, 16, 17, 19};
 //
 long Alg_reader::parse_key(string &field)
 {
-    char *msg = "Pitch expected";
-    char *pitches = "ABCDEFG";
-    char *p;
+    const char *msg = "Pitch expected";
+    const char *pitches = "ABCDEFG";
+    const char *p;
     if (isdigit(field[1])) {
         // This routine would not have been called if field = "P<number>"
         // so it must be "K<number>" so <number> must be an integer.

--- a/src/allegrosmfrd.cpp
+++ b/src/allegrosmfrd.cpp
@@ -74,7 +74,7 @@ protected:
     void Mf_chanprefix(int chan);
     void Mf_portprefix(int port);
     void Mf_eot();
-    void Mf_error(char *);
+    void Mf_error(const char *);
     void Mf_header(int,int,int);
     void Mf_on(int,int,int);
     void Mf_off(int,int,int);
@@ -169,7 +169,7 @@ void Alg_midifile_reader::Mf_eot()
 }
 
 
-void Alg_midifile_reader::Mf_error(char *msg)
+void Alg_midifile_reader::Mf_error(const char *msg)
 {
     fprintf(stdout, "Midifile reader error: %s\n", msg);
 }
@@ -353,7 +353,7 @@ void Alg_midifile_reader::Mf_seqnum(int n)
 }
 
 
-static char *fpsstr[4] = {"24", "25", "29.97", "30"};
+static const char *fpsstr[4] = {"24", "25", "29.97", "30"};
 
 void Alg_midifile_reader::Mf_smpte(int hours, int mins, int secs,
                                    int frames, int subframes)

--- a/src/mfmidi.cpp
+++ b/src/mfmidi.cpp
@@ -35,7 +35,7 @@ void Midifile_reader::midifile()
     while (ntrks-- > 0 && !midifile_error) readtrack();
 }
 
-int Midifile_reader::readmt(char *s, int skip)
+int Midifile_reader::readmt(const char *s, int skip)
     /* read through the "MThd" or "MTrk" header string */
     /* if skip == 1, we attempt to skip initial garbage. */
 {
@@ -44,7 +44,7 @@ int Midifile_reader::readmt(char *s, int skip)
     char b[4];
     char buff[32];
     int c;
-    char *errmsg = "expecting ";
+    const char *errmsg = "expecting ";
 
     retry:
     while ( nread<4 ) {
@@ -414,7 +414,7 @@ int Midifile_reader::read16bit()
     return to16bit(c1,c2);
 }
 
-void Midifile_reader::mferror(char *s)
+void Midifile_reader::mferror(const char *s)
 {
     Mf_error(s);
     midifile_error = 1;


### PR DESCRIPTION
Fixes the build warnings seen during build. You can see them in the logs here: https://github.com/tenacityteam/portsmf/runs/3090554258?check_suite_focus=true#step:4:1

Ran the tests (except 17, 19, and 21 as those still segfault; 32 and 33 aren't running since a file is missing it looks like) and all look to be working still.