### PR TITLE
More warnings cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.0)
 
 project(PortSMF VERSION 235.1 LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 11)
 
 option(BUILD_SHARED_LIBS "Build dynamic library" ON)
 

--- a/include/allegro.h
+++ b/include/allegro.h
@@ -669,7 +669,11 @@ public:
     Alg_track(Alg_event_list_ref event_list, Alg_time_map_ptr map,
               bool units_are_seconds);
     virtual ~Alg_track() { // note: do not call set_time_map(NULL)!
-        if (time_map) time_map->dereference(); time_map = NULL; }
+        if (time_map) {
+            time_map->dereference();
+        }
+        time_map = NULL;
+    }
 
     // Returns a buffer containing a serialization of the
     // file.  It will be an ASCII representation unless text is true.

--- a/include/allegro.h
+++ b/include/allegro.h
@@ -77,7 +77,7 @@ class Alg_atoms {
 public:
     Alg_atoms() {
         maxlen = len = 0;
-        atoms = NULL;
+        atoms = nullptr;
     }
     // Note: the code is possibly more correct and faster without the
     // following destructor, which will only run after the program takes
@@ -249,7 +249,7 @@ public:
         // 'r' = real (double), 'l' = logical (bool), 'i' = integer (long),
         // 'a' = atom (char *), a unique string stored in Alg_seq
     // get the string value
-    const char *get_string_value(const char *attr, const char *value = NULL);
+    const char *get_string_value(const char *attr, const char *value = nullptr);
     // get the real value
     double get_real_value(const char *attr, double value = 0.0);
     // get the logical value
@@ -257,7 +257,7 @@ public:
     // get the integer value
     long get_integer_value(const char *attr, long value = 0);
     // get the atom value
-    const char *get_atom_value(const char *attr, const char *value = NULL);
+    const char *get_atom_value(const char *attr, const char *value = nullptr);
     void delete_attribute(const char *attr);   // delete an attribute/value pair
         // (ignore if no matching attribute/value pair exists)
 
@@ -298,7 +298,7 @@ public:
     float loud;  // dynamic corresponding to MIDI velocity
     double dur;   // duration in seconds (normally to release point)
     Alg_parameters_ptr parameters; // attribute/value pair list
-    Alg_note() { type = 'n'; parameters = NULL; }
+    Alg_note() { type = 'n'; parameters = nullptr; }
     void show();
 } *Alg_note_ptr;
 
@@ -341,7 +341,7 @@ public:
     }
     Alg_events() {
         maxlen = len = 0;
-        events = NULL;
+        events = nullptr;
         last_note_off = 0;
         in_use = false;
     }
@@ -393,7 +393,7 @@ public:
     // particularly fast on an Alg_seq.
     virtual Alg_event_ptr &operator[](int i);
     Alg_event_list() { sequence_number = 0;
-        beat_dur = 0.0; real_dur = 0.0; events_owner = NULL; type = 'e'; }
+        beat_dur = 0.0; real_dur = 0.0; events_owner = nullptr; type = 'e'; }
     Alg_event_list(Alg_track *owner);
 
     char get_type() { return type; }
@@ -456,7 +456,7 @@ public:
     }
     Alg_beats() {
         maxlen = len = 0;
-        beats = NULL;
+        beats = nullptr;
         expand();
         beats[0].time = 0;
         beats[0].beat = 0;
@@ -530,8 +530,8 @@ class Serial_buffer {
     long len;
   public:
     Serial_buffer() {
-        buffer = NULL;
-        ptr = NULL;
+        buffer = nullptr;
+        ptr = nullptr;
         len = 0;
     }
     virtual ~Serial_buffer() { }
@@ -657,8 +657,8 @@ public:
         assert(i >= 0 && i < len);
         return events[i];
     }
-    Alg_track() { units_are_seconds = false; time_map = NULL;
-                  set_time_map(NULL); type = 't'; }
+    Alg_track() { units_are_seconds = false; time_map = nullptr;
+                  set_time_map(nullptr); type = 't'; }
     // initialize empty track with a time map
     Alg_track(Alg_time_map *map, bool seconds);
 
@@ -668,11 +668,11 @@ public:
     // copy constructor: event_list is copied, map is installed and referenced
     Alg_track(Alg_event_list_ref event_list, Alg_time_map_ptr map,
               bool units_are_seconds);
-    virtual ~Alg_track() { // note: do not call set_time_map(NULL)!
+    virtual ~Alg_track() { // note: do not call set_time_map(nullptr)!
         if (time_map) {
             time_map->dereference();
         }
-        time_map = NULL;
+        time_map = nullptr;
     }
 
     // Returns a buffer containing a serialization of the
@@ -688,7 +688,7 @@ public:
     // If the track is really an Alg_seq and you need to access an
     // Alg_seq method, coerce to an Alg_seq with this function:
     Alg_seq_ptr to_alg_seq() {
-        return (get_type() == 's' ? (Alg_seq_ptr) this : NULL); }
+        return (get_type() == 's' ? (Alg_seq_ptr) this : nullptr); }
 
     // Are we using beats or seconds?
     bool get_units_are_seconds() { return units_are_seconds; }
@@ -699,11 +699,11 @@ public:
     double get_dur() { return (units_are_seconds ? real_dur : beat_dur); }
 
     // Every Alg_track may have an associated time_map. If no map is
-    // specified, or if you set_time_map(NULL), then the behavior
+    // specified, or if you set_time_map(nullptr), then the behavior
     // should be as if there is a constant tempo of 100 beats/minute
     // (this constant is determined by ALG_DEFAULT_BPM).
     // Recommendation: create a static global tempo map object. When
-    // any operation that needs a tempo map gets NULL, use the global
+    // any operation that needs a tempo map gets nullptr, use the global
     // tempo map. (Exception: any operation that would modify the
     // tempo map should raise an error -- you don't want to change the
     // default tempo map.)
@@ -860,7 +860,7 @@ private:
 public:
     Alg_time_sigs() {
         maxlen = len = 0;
-        time_sigs = NULL;
+        time_sigs = nullptr;
     }
     Alg_time_sig &operator[](int i) { // fetch a time signature
         assert(i >= 0 && i < len);
@@ -900,7 +900,7 @@ public:
     long length() { return len; }
     Alg_tracks() {
         maxlen = len = 0;
-        tracks = NULL;
+        tracks = nullptr;
     }
     ~Alg_tracks();
     // Append a track to tracks. This Alg_tracks becomes the owner of track.
@@ -961,7 +961,7 @@ public:
         seq = s;
         note_off_flag = note_off;
         maxlen = len = 0;
-        pending_events = NULL;
+        pending_events = nullptr;
     }
     // Normally, iteration is over the events in the one sequence used
     // to instatiate the iterator (see above), but with this method, you
@@ -971,14 +971,14 @@ public:
     // before merging/sorting. You should call begin_seq() for each
     // sequence to be included in the iteration unless you call begin()
     // (see below).
-    void begin_seq(Alg_seq_ptr s, void *cookie = NULL, double offset = 0.0);
+    void begin_seq(Alg_seq_ptr s, void *cookie = nullptr, double offset = 0.0);
     ~Alg_iterator();
     // Prepare to enumerate events in order. If note_off_flag is true, then
     // iteration_next will merge note-off events into the sequence. If you
     // call begin(), you should not normally call begin_seq(). See above.
-    void begin(void *cookie = NULL) { begin_seq(seq, cookie); }
-    // return next event (or NULL). If iteration_begin was called with
-    // note_off_flag = true, and if note_on is not NULL, then *note_on
+    void begin(void *cookie = nullptr) { begin_seq(seq, cookie); }
+    // return next event (or nullptr). If iteration_begin was called with
+    // note_off_flag = true, and if note_on is not nullptr, then *note_on
     // is set to true when the result value represents a note-on or update.
     // (With note_off_flag, each Alg_note event is returned twice, once
     // at the note-on time, with *note_on == true, and once at the note-off
@@ -986,8 +986,8 @@ public:
     // cookie corresponding to the event is stored at that address
     // If end_time is 0, iterate through the entire sequence, but if
     // end_time is non_zero, stop iterating at the last event before end_time
-    Alg_event_ptr next(bool *note_on = NULL, void **cookie_ptr = NULL,
-                       double *offset_ptr = NULL, double end_time = 0);
+    Alg_event_ptr next(bool *note_on = nullptr, void **cookie_ptr = nullptr,
+                       double *offset_ptr = nullptr, double end_time = 0);
     // Sometimes, the caller wants to receive note-off events for a subset
     // of the notes, typically the notes that are played and need to be
     // turned off. In this case, when a note is turned on, the client
@@ -1029,9 +1029,9 @@ public:
     Alg_seq(Alg_track_ptr track) { seq_from_track(*track); }
     void seq_from_track(Alg_track_ref tr);
     // create from file:
-    Alg_seq(std::istream &file, bool smf, double *offset_ptr = NULL);
+    Alg_seq(std::istream &file, bool smf, double *offset_ptr = nullptr);
     // create from filename
-    Alg_seq(const char *filename, bool smf, double *offset_ptr = NULL);
+    Alg_seq(const char *filename, bool smf, double *offset_ptr = nullptr);
     virtual ~Alg_seq();
     int get_read_error() { return error; }
     void serialize(void **buffer, long *bytes);

--- a/include/allegro.h
+++ b/include/allegro.h
@@ -1102,7 +1102,7 @@ public:
     // add_event takes a pointer to an event on the heap. The event is not
     // copied, and this Alg_seq becomes the owner and freer of the event.
     void add_event(Alg_event_ptr event, int track_num);
-    void add(Alg_event_ptr event) { assert(false); } // call add_event instead
+    void add(Alg_event_ptr /*event*/) { assert(false); } // call add_event instead
     // get the tempo starting at beat
     double get_tempo(double beat);
     bool set_tempo(double bpm, double start_beat, double end_beat);

--- a/src/algrd_internal.h
+++ b/src/algrd_internal.h
@@ -1,5 +1,5 @@
 /* algread_internal.h -- interface between allegro.cpp and allegrord.cpp */
 
 Alg_error alg_read(std::istream &file, Alg_seq_ptr new_seq,
-                   double *offset_ptr = NULL);
+                   double *offset_ptr = nullptr);
 

--- a/src/allegro.cpp
+++ b/src/allegro.cpp
@@ -205,12 +205,12 @@ Alg_parameters *Alg_parameters::remove_key(Alg_parameters **list,
         if (STREQL((*list)->parm.attr_name(), name)) {
             Alg_parameters_ptr p = *list;
             *list = p->next;
-            p->next = NULL;
+            p->next = nullptr;
             return p; // caller should free this pointer
         }
         list = &((*list)->next);
     }
-    return NULL;
+    return nullptr;
 }
 
 
@@ -223,7 +223,7 @@ Alg_parameter_ptr Alg_parameters::find(Alg_attribute attr)
             return &(temp->parm);
         }
     }
-    return NULL;
+    return nullptr;
 }
 
 
@@ -285,7 +285,7 @@ void Alg_event::set_string_value(const char *a, const char *value)
     parm.set_attr(attr);
     parm.s = value;
     set_parameter(&parm);
-    parm.s = NULL; // do this to prevent string from being freed
+    parm.s = nullptr; // do this to prevent string from being freed
 }
 
 
@@ -301,7 +301,7 @@ void Alg_event::set_real_value(const char *a, double value)
     parm.set_attr(attr);
     parm.r = value;
     set_parameter(&parm);
-    // since type is 'r' we don't have to NULL the string
+    // since type is 'r' we don't have to nullptr the string
 }
 
 
@@ -314,7 +314,7 @@ void Alg_event::set_logical_value(const char *a, bool value)
     parm.set_attr(attr);
     parm.l = value;
     set_parameter(&parm);
-    // since type is 'l' we don't have to NULL the string
+    // since type is 'l' we don't have to nullptr the string
 }
 
 
@@ -327,7 +327,7 @@ void Alg_event::set_integer_value(const char *a, long value)
     parm.set_attr(attr);
     parm.i = value;
     set_parameter(&parm);
-    // since tpye is 'i' we don't have to NULL the string
+    // since tpye is 'i' we don't have to nullptr the string
 }
 
 
@@ -414,7 +414,7 @@ bool Alg_event::has_attribute(const char *a)
     Alg_note* note = (Alg_note *) this;
     Alg_attribute attr = symbol_table.insert_string(a);
     Alg_parameter_ptr parm = note->parameters->find(attr);
-    return parm != NULL;
+    return parm != nullptr;
 }
 
 
@@ -489,7 +489,7 @@ const char *Alg_event::get_atom_value(const char *a, const char *value)
     if (parm) return parm->a;
     // if default is a string, convert to an atom (unique
     // string in symbol table) and return it
-    return (value == NULL ? NULL :
+    return (value == nullptr ? nullptr :
               symbol_table.insert_string(value));
 }
 
@@ -1244,7 +1244,7 @@ void Alg_time_map::insert_beats(double start, double len)
 Alg_track::Alg_track(Alg_time_map *map, bool seconds)
 {
     type = 't';
-    time_map = NULL;
+    time_map = nullptr;
     units_are_seconds = seconds;
     set_time_map(map);
 }
@@ -1265,7 +1265,7 @@ Alg_event_ptr Alg_track::copy_event(Alg_event_ptr event)
 Alg_track::Alg_track(Alg_track &track)
 {
     type = 't';
-    time_map = NULL;
+    time_map = nullptr;
     for (int i = 0; i < track.length(); i++) {
       append(copy_event(track.events[i]));
     }
@@ -1278,7 +1278,7 @@ Alg_track::Alg_track(Alg_event_list_ref event_list, Alg_time_map_ptr map,
                      bool units_are_seconds)
 {
     type = 't';
-    time_map = NULL;
+    time_map = nullptr;
     for (int i = 0; i < event_list.length(); i++) {
         append(copy_event(event_list[i]));
     }
@@ -1628,7 +1628,7 @@ void Alg_track::unserialize_track()
             // (although order shouldn't matter)
             Alg_parameters_ptr *list = &note->parameters;
             for (j = 0; j < param_num; j++) {
-                *list = new Alg_parameters(NULL);
+                *list = new Alg_parameters(nullptr);
                 unserialize_parameter(&((*list)->parm));
                 list = &((*list)->next);
             }
@@ -1679,7 +1679,7 @@ void Alg_track::unserialize_parameter(Alg_parameter_ptr parm_ptr)
 void Alg_track::set_time_map(Alg_time_map *map)
 {
     if (time_map) time_map->dereference();
-    if (map == NULL) {
+    if (map == nullptr) {
         time_map = new Alg_time_map(); // new default map
         time_map->reference();
     } else {
@@ -2629,7 +2629,7 @@ void Alg_tracks::reset()
         delete tracks[i];
     }
     if (tracks) delete [] tracks;
-    tracks = NULL;
+    tracks = nullptr;
     len = 0;
     maxlen = 0;
 }
@@ -2958,7 +2958,7 @@ Alg_seq_ptr Alg_seq::cut(double start, double len, bool all)
 {
     double dur = get_dur();
     // fix parameters to fall within existing sequence
-    if (start > dur) return NULL; // nothing to cut
+    if (start > dur) return nullptr; // nothing to cut
     if (start < 0) start = 0; // can't start before sequence starts
     if (start + len > dur) // can't cut after end:
         len = dur - start;
@@ -3063,7 +3063,7 @@ Alg_track_ptr Alg_seq::copy_track(int track_num, double t, double len, bool all)
 Alg_seq *Alg_seq::copy(double start, double len, bool all)
 {
     // fix parameters to fall within existing sequence
-    if (start > get_dur()) return NULL; // nothing to copy
+    if (start > get_dur()) return nullptr; // nothing to copy
     if (start < 0) start = 0; // can't copy before sequence starts
     if (start + len > get_dur()) // can't copy after end:
         len = get_dur() - start;
@@ -3449,7 +3449,7 @@ Alg_event_ptr Alg_iterator::next(bool *note_on, void **cookie_ptr,
     bool on;
     double when;
     if (!remove_next(events_ptr, index, on, cookie, offset, when)) {
-        return NULL;
+        return nullptr;
     }
     if (note_on) *note_on = on;
     Alg_event_ptr event = (*events_ptr)[index];

--- a/src/allegro.cpp
+++ b/src/allegro.cpp
@@ -14,6 +14,7 @@
 #include <cstdio>
 #include <cstring>
 #include <fstream>
+#include <stdexcept>
 #include "allegro.h"
 #include "algrd_internal.h"
 #include "algsmfrd_internal.h"
@@ -2886,7 +2887,8 @@ Alg_event_ptr &Alg_seq::operator[](int i)
         }
         tr++;
     }
-    assert(false); // out of bounds
+    // throw runtime error instead of using assert
+    throw std::runtime_error("&Alg_seq::operator[] - out of bounds");
 }
 #if defined(_WIN32)
 #pragma warning(default: 4715)

--- a/src/allegro.cpp
+++ b/src/allegro.cpp
@@ -2383,6 +2383,7 @@ void Alg_time_sigs::paste(double start, Alg_seq *seq)
     double num_of_insert = 4.0;
     double den_of_insert = 4.0;
     double beat_of_insert = 0.0;
+    // TODO: check if first_from_index is needed
     int first_from_index = 0; // where to start copying from
     if (from.length() > 0 && from[0].beat < ALG_EPS) {
         // there is an initial time signature in "from"
@@ -2392,6 +2393,7 @@ void Alg_time_sigs::paste(double start, Alg_seq *seq)
         // we can start copying at index == 1:
         first_from_index = 1;
     }
+    static_cast<void>(first_from_index); // first_from_index is unused, so silence warning for now
     // compare time signatures to see if we need a change at start:
     if (num_before_splice != num_of_insert ||
         den_before_splice != den_of_insert) {

--- a/src/allegro.cpp
+++ b/src/allegro.cpp
@@ -23,10 +23,12 @@
 #define MAX(x, y) ((x) > (y) ? (x) : (y))
 #define ROUND(x) ((int) ((x) + 0.5))
 
+#if defined(_WIN32)
 // 4311 is type cast ponter to long warning
 // 4996 is warning against strcpy
 // 4267 is size_t to long warning
 #pragma warning(disable: 4311 4996 4267)
+#endif
 Alg_atoms symbol_table;
 Serial_read_buffer Alg_track::ser_read_buf; // declare the static variables
 Serial_write_buffer Alg_track::ser_write_buf;
@@ -1535,7 +1537,9 @@ Alg_track *Alg_track::unserialize(void *buffer, long len)
 }
 
 
+#if defined(_WIN32)
 #pragma warning(disable: 4800) // long to bool performance warning
+#endif
 
 /* Note: this Alg_seq must have a default initialized Alg_time_map.
  * It will be filled in with data from the ser_read_buf buffer.
@@ -1668,7 +1672,9 @@ void Alg_track::unserialize_parameter(Alg_parameter_ptr parm_ptr)
     }
 }
 
+#if defined(_WIN32)
 #pragma warning(default: 4800)
+#endif
 
 void Alg_track::set_time_map(Alg_time_map *map)
 {
@@ -2860,7 +2866,9 @@ Alg_track_ptr Alg_seq::track(int i)
     return &(track_list[i]);
 }
 
+#if defined(_WIN32)
 #pragma warning(disable: 4715) // ok not to return a value here
+#endif
 
 Alg_event_ptr &Alg_seq::operator[](int i)
 {
@@ -2877,7 +2885,9 @@ Alg_event_ptr &Alg_seq::operator[](int i)
     }
     assert(false); // out of bounds
 }
+#if defined(_WIN32)
 #pragma warning(default: 4715)
+#endif
 
 
 void Alg_seq::convert_to_beats()

--- a/src/allegro.cpp
+++ b/src/allegro.cpp
@@ -1263,6 +1263,7 @@ Alg_event_ptr Alg_track::copy_event(Alg_event_ptr event)
 
 
 Alg_track::Alg_track(Alg_track &track)
+    : Alg_event_list(track)
 {
     type = 't';
     time_map = nullptr;

--- a/src/allegrord.cpp
+++ b/src/allegrord.cpp
@@ -163,7 +163,7 @@ bool Alg_reader::parse()
         double new_pitch = 0.0;
         bool new_key_flag = false;   // "K" syntax
         int new_key = 0;
-        Alg_parameters_ptr attributes = NULL;
+        Alg_parameters_ptr attributes = nullptr;
         if (line_parser.peek() == '#') {
             // look for #track
             line_parser.get_nonspace_quoted(field);
@@ -295,7 +295,7 @@ bool Alg_reader::parse()
                     if (parse_attribute(field, &parm)) { // enter attribute-value pair
                         attributes = new Alg_parameters(attributes);
                         attributes->parm = parm;
-                        parm.s = NULL; // protect string from deletion by destructor
+                        parm.s = nullptr; // protect string from deletion by destructor
                     }
                 } else {
                     parse_error(field, 0, "Unknown field");
@@ -393,7 +393,7 @@ bool Alg_reader::parse()
                             seq->add_event(new_upd, track_num);
                             Alg_parameters_ptr p = attributes;
                             attributes = attributes->next;
-                            p->parm.s = NULL; // so we don't delete the string
+                            p->parm.s = nullptr; // so we don't delete the string
                             delete p;
                         }
                     }
@@ -579,7 +579,7 @@ struct loud_lookup_struct {
     int val;
 } loud_lookup[] = { {"FFF", 127}, {"FF", 120}, {"F", 110}, {"MF", 100},
                     {"MP", 90}, {"P", 80}, {"PP", 70}, {"PPP", 60},
-                    {NULL, 0} };
+                    {nullptr, 0} };
 
 
 double Alg_reader::parse_loud(string &field)

--- a/src/allegrord.cpp
+++ b/src/allegrord.cpp
@@ -713,11 +713,12 @@ bool Alg_reader::parse_val(Alg_parameter_ptr param, string &s, int i)
     } else if (isdigit(s[i]) || s[i] == '-' || s[i] == '.') {
         int pos = i;
         bool period = false;
-        int sign = 1;
+        int sign = 1; // TODO: check if sign is needed
         if (s[pos] == '-') {
             sign = -1;
             pos++;
         }
+        static_cast<void>(sign); // sign is unused, so silence warning for now
         while (pos < len) {
             if (isdigit(s[pos])) {
                 ;

--- a/src/allegrosmfrd.cpp
+++ b/src/allegrosmfrd.cpp
@@ -62,7 +62,7 @@ protected:
     double get_time();
     void update(int chan, int key, Alg_parameter_ptr param);
     void *Mf_malloc(size_t size) { return malloc(size); }
-    void Mf_free(void *obj, size_t size) { free(obj); }
+    void Mf_free(void *obj, size_t /*size*/) { free(obj); }
     /* Methods to be called while processing the MIDI file. */
     void Mf_starttrack();
     void Mf_endtrack();
@@ -171,7 +171,7 @@ void Alg_midifile_reader::Mf_error(const char *msg)
 }
 
 
-void Alg_midifile_reader::Mf_header(int format, int ntrks, int division)
+void Alg_midifile_reader::Mf_header(int format, int /*ntrks*/, int division)
 {
     if (format > 1) {
         char msg[80];
@@ -216,7 +216,7 @@ void Alg_midifile_reader::Mf_on(int chan, int key, int vel)
 }
 
 
-void Alg_midifile_reader::Mf_off(int chan, int key, int vel)
+void Alg_midifile_reader::Mf_off(int chan, int key, int /*vel*/)
 {
     double time = get_time();
     Alg_note_list_ptr *p = &note_list;
@@ -339,13 +339,13 @@ void Alg_midifile_reader::Mf_sysex(int len, unsigned char *msg)
 }
 
 
-void Alg_midifile_reader::Mf_arbitrary(int len, unsigned char *msg)
+void Alg_midifile_reader::Mf_arbitrary(int /*len*/, unsigned char* /*msg*/)
 {
     Mf_error("arbitrary data ignored");
 }
 
 
-void Alg_midifile_reader::Mf_metamisc(int type, int len, unsigned char *msg)
+void Alg_midifile_reader::Mf_metamisc(int type, int /*len*/, unsigned char* /*msg*/)
 {
     char text[128];
 #if defined(_WIN32)
@@ -359,7 +359,7 @@ void Alg_midifile_reader::Mf_metamisc(int type, int len, unsigned char *msg)
 }
 
 
-void Alg_midifile_reader::Mf_seqnum(int n)
+void Alg_midifile_reader::Mf_seqnum(int /*n*/)
 {
     Mf_error("seqnum data ignored");
 }
@@ -391,7 +391,7 @@ void Alg_midifile_reader::Mf_smpte(int hours, int mins, int secs,
 }
 
 
-void Alg_midifile_reader::Mf_timesig(int i1, int i2, int i3, int i4)
+void Alg_midifile_reader::Mf_timesig(int i1, int i2, int /*i3*/, int /*i4*/)
 {
     seq->set_time_sig(double(get_currtime()) / divisions, i1, 1 << i2);
 }

--- a/src/allegrosmfrd.cpp
+++ b/src/allegrosmfrd.cpp
@@ -175,9 +175,13 @@ void Alg_midifile_reader::Mf_header(int format, int ntrks, int division)
 {
     if (format > 1) {
         char msg[80];
+#if defined(_WIN32)
 #pragma warning(disable: 4996) // msg is long enough
+#endif
         sprintf(msg, "file format %d not implemented", format);
+#if defined(_WIN32)
 #pragma warning(default: 4996)
+#endif
         Mf_error(msg);
     }
     divisions = division;
@@ -264,9 +268,13 @@ void Alg_midifile_reader::Mf_controller(int chan, int control, int val)
 {
     Alg_parameter parameter;
     char name[32];
+#if defined(_WIN32)
 #pragma warning(disable: 4996) // name is long enough
+#endif
     sprintf(name, "control%dr", control);
+#if defined(_WIN32)
 #pragma warning(default: 4996)
+#endif
     parameter.set_attr(symbol_table.insert_string(name));
     parameter.r = val / 127.0;
     update(chan, -1, &parameter);
@@ -310,9 +318,13 @@ void Alg_midifile_reader::binary_msg(int len, unsigned char *msg,
     Alg_parameter parameter;
     char *hexstr = new char[len * 2 + 1];
     for (int i = 0; i < len; i++) {
+#if defined(_WIN32)
 #pragma warning(disable: 4996) // hexstr is long enough
+#endif
         sprintf(hexstr + 2 * i, "%02x", (0xFF & msg[i]));
+#if defined(_WIN32)
 #pragma warning(default: 4996)
+#endif
     }
     parameter.s = hexstr;
     parameter.set_attr(symbol_table.insert_string(attr_string));
@@ -336,9 +348,13 @@ void Alg_midifile_reader::Mf_arbitrary(int len, unsigned char *msg)
 void Alg_midifile_reader::Mf_metamisc(int type, int len, unsigned char *msg)
 {
     char text[128];
+#if defined(_WIN32)
 #pragma warning(disable: 4996) // text is long enough
+#endif
     sprintf(text, "metamsic data, type 0x%x, ignored", type);
+#if defined(_WIN32)
 #pragma warning(default: 4996)
+#endif
     Mf_error(text);
 }
 
@@ -359,10 +375,14 @@ void Alg_midifile_reader::Mf_smpte(int hours, int mins, int secs,
     char text[32];
     int fps = (hours >> 6) & 3;
     hours &= 0x1F;
+#if defined(_WIN32)
 #pragma warning(disable: 4996) // text is long enough
+#endif
     sprintf(text, "%sfps:%02dh:%02dm:%02ds:%02d.%02df",
             fpsstr[fps], hours, mins, secs, frames, subframes);
+#if defined(_WIN32)
 #pragma warning(default: 4996)
+#endif
     Alg_parameter smpteoffset;
     smpteoffset.s = heapify(text);
     smpteoffset.set_attr(symbol_table.insert_string("smpteoffsets"));

--- a/src/allegrosmfrd.cpp
+++ b/src/allegrosmfrd.cpp
@@ -37,7 +37,7 @@ public:
 
     Alg_midifile_reader(std::istream &f, Alg_seq_ptr new_seq) {
         file = &f;
-        note_list = NULL;
+        note_list = nullptr;
         seq = new_seq;
         channel_offset_per_track = 0;
         channel_offset_per_port = 16;
@@ -45,7 +45,7 @@ public:
         meta_channel = -1;
         port = 0;
     }
-    // delete destroys the seq member as well, so set it to NULL if you
+    // delete destroys the seq member as well, so set it to nullptr if you
     // copied the pointer elsewhere
     ~Alg_midifile_reader();
     // the following is used to load the Alg_seq from the file:
@@ -132,7 +132,7 @@ void Alg_midifile_reader::Mf_endtrack()
     // note: track is already part of seq, so do not add it here
     // printf("finished track, length %d number %d\n", track->len, track_num / 100);
     channel_offset += seq->channel_offset_per_track;
-    track = NULL;
+    track = nullptr;
     double now = get_time();
     if (seq->get_beat_dur() < now) seq->set_beat_dur(now);
     meta_channel = -1;
@@ -249,7 +249,7 @@ void Alg_midifile_reader::update(int chan, int key, Alg_parameter_ptr param)
     update->parameter = *param;
     // prevent the destructor from destroying the string twice!
     // the new Update takes the string from param
-    if (param->attr_type() == 's') param->s = NULL;
+    if (param->attr_type() == 's') param->s = nullptr;
     track->append(update);
 }
 

--- a/src/allegrosmfwr.cpp
+++ b/src/allegrosmfwr.cpp
@@ -75,7 +75,7 @@ private:
 
 Alg_smf_write::Alg_smf_write(Alg_seq_ptr a_seq)
 {
-    out_file = NULL;
+    out_file = nullptr;
 
     // at 100bpm (a nominal tempo value), we would like a division
     // to represent 1ms of time. So
@@ -119,19 +119,19 @@ Alg_smf_write::~Alg_smf_write()
 event_queue* push(event_queue *queue, event_queue *event)
 {
     // printf("push: %.6g, %c, %d\n", event->time, event->type, event->index);
-    if (queue == NULL) {
-        event->next = NULL;
+    if (queue == nullptr) {
+        event->next = nullptr;
         return event;
     }
 
-    event_queue *marker1 = NULL;
+    event_queue *marker1 = nullptr;
     event_queue *marker2 = queue;
-    while (marker2 != NULL && marker2->time <= event->time) {
+    while (marker2 != nullptr && marker2->time <= event->time) {
         marker1 = marker2;
         marker2 = marker2->next;
     }
     event->next = marker2;
-    if (marker1 != NULL) {
+    if (marker1 != nullptr) {
         marker1->next=event;
         return queue;
     } else return event;
@@ -411,17 +411,17 @@ void Alg_smf_write::write_track(int i)
 {
     int j = 0; // note index
     Alg_events &notes = seq->track_list[i];
-    event_queue *pending = NULL;
+    event_queue *pending = nullptr;
     if (notes.length() > 0) {
-        pending = new event_queue('n', TICK_TIME(notes[j]->time, 0), 0, NULL);
+        pending = new event_queue('n', TICK_TIME(notes[j]->time, 0), 0, nullptr);
     }
     if (i == 0) { // track 0 may have tempo and timesig info
         if (seq->get_time_map()->last_tempo_flag || seq->get_time_map()->beats.len > 0) {
-            pending = push(pending, new event_queue('c', 0.0, 0, NULL));
+            pending = push(pending, new event_queue('c', 0.0, 0, nullptr));
         }
         if (seq->time_sig.length() > 0) {
             pending = push(pending, new event_queue('s',
-                           TICK_TIME(seq->time_sig[0].beat, 0), 0, NULL));
+                           TICK_TIME(seq->time_sig[0].beat, 0), 0, nullptr));
         }
     }
     while (pending) {
@@ -432,7 +432,7 @@ void Alg_smf_write::write_track(int i)
             if (n->is_note()) {
                 write_note(n, true);
                 pending = push(pending, new event_queue('o',
-                      TICK_TIME(n->time + n->dur, -1), current->index, NULL));
+                      TICK_TIME(n->time + n->dur, -1), current->index, nullptr));
             } else if (n->is_update()) {
                 Alg_update_ptr u = (Alg_update_ptr) n;
                 write_update(u);

--- a/src/allegrowr.cpp
+++ b/src/allegrowr.cpp
@@ -53,7 +53,7 @@ Alg_event_ptr Alg_seq::write_track_name(std::ostream &file, int n,
 // find a name and write it, return a pointer to it so the track
 // writer knows what update (if any) to skip
 {
-    Alg_event_ptr e = NULL; // e is the result, default is NULL
+    Alg_event_ptr e = nullptr; // e is the result, default is nullptr
     file << "#track " << n;
     const char *attr = symbol_table.insert_string(
                                n == 0 ? "seqnames" : "tracknames");

--- a/src/mfmidi.cpp
+++ b/src/mfmidi.cpp
@@ -68,10 +68,14 @@ int Midifile_reader::readmt(const char *s, int skip)
         goto retry;
     }
     err:
+#if defined(_WIN32)
 #pragma warning(disable: 4996) // strcpy is safe since strings have known lengths
+#endif
     (void) strcpy(buff,errmsg);
     (void) strcat(buff,s);
+#if defined(_WIN32)
 #pragma warning(default: 4996) // turn it back on
+#endif
     mferror(buff);
     return(0);
 }
@@ -257,9 +261,13 @@ void Midifile_reader::readtrack()
 void Midifile_reader::badbyte(int c)
 {
     char buff[32];
+#if defined(_WIN32)
 #pragma warning(disable: 4996) // safe in this case
+#endif
     (void) sprintf(buff,"unexpected byte: 0x%02x",c);
+#if defined(_WIN32)
 #pragma warning(default: 4996)
+#endif
     mferror(buff);
 }
 

--- a/src/mfmidi.cpp
+++ b/src/mfmidi.cpp
@@ -449,7 +449,7 @@ Midifile_reader::Midifile_reader()
 void Midifile_reader::finalize()
 {
     if (Msgbuff) Mf_free(Msgbuff, Msgsize);
-    Msgbuff = NULL;
+    Msgbuff = nullptr;
 }
 
 

--- a/src/trace.cpp
+++ b/src/trace.cpp
@@ -18,7 +18,7 @@ void trace(char *format, ...)
     _vsnprintf_s(msg, 256, _TRUNCATE, format, args);
     va_end(args);
 #ifdef _DEBUG
-    _CrtDbgReport(_CRT_WARN, NULL, NULL, NULL, msg);
+    _CrtDbgReport(_CRT_WARN, nullptr, nullptr, nullptr, msg);
 #else
     printf(msg);
 #endif

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -747,6 +747,7 @@ void test33() // cut and inspect some notes
     ofile.close();
 
     Alg_seq_ptr cut = seq->cut(0.0, 3.0, false);
+    static_cast<void>(cut); // cut is unused, so silence warning
 
     tm = seq->get_time_map();
     printf("timemap %p after\n", static_cast<void*>(tm));

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -739,7 +739,7 @@ void test33() // cut and inspect some notes
     seq->convert_to_seconds();
 
     Alg_time_map_ptr tm = seq->get_time_map();
-    printf("time map %p before\n", tm);
+    printf("time map %p before\n", static_cast<void*>(tm));
     // tm->show();
     printf("timestamp before %.15g\n", tm->beats[tm->locate_time(3.74)].time);
     ofstream ofile("before-33.alg", ios::out | ios::binary);
@@ -749,7 +749,7 @@ void test33() // cut and inspect some notes
     Alg_seq_ptr cut = seq->cut(0.0, 3.0, false);
 
     tm = seq->get_time_map();
-    printf("timemap %p after\n", tm);
+    printf("timemap %p after\n", static_cast<void*>(tm));
     // tm->show();
     printf("timestamp after %.15g\n", tm->beats[tm->locate_time(0.74)].time);
     ofile.open("after-33.alg",  ios::out | ios::binary);


### PR DESCRIPTION
Enabled `-Wall -Wextra -pedantic` (and maybe a few others at some points 😄) and got some more cleanup done.

* All the `#pragma`s are WIN32 build ones, so guarding those with `#if defined(_WIN32)` similar to elsewhere in code.
* Use of `%p` needed pointers to be cast to `void*`
* Unbraced if statement threw indentation warning
* Many unused parameters/variables
* Warning for not using the parent class constructor in a copy constructor
* The `control reaches end of non-void function` fixed with throwing a runtime error; the previous `assert` would throw an error but it looks like the assert is optimized out in the runner's gcc and clang versions, so we just explicitly throw one now
* All `NULL` have been converted to `nullptr`